### PR TITLE
CI: Add ci-management CI jobs

### DIFF
--- a/jenkins-config/clouds/openstack/magmaci/centos7-builder-2c-1g.cfg
+++ b/jenkins-config/clouds/openstack/magmaci/centos7-builder-2c-1g.cfg
@@ -1,0 +1,4 @@
+IMAGE_NAME=ZZCI - CentOS 7 - builder - x86_64 - 20200224-191258.235
+LABELS=centos7-builder-2c-1g
+HARDWARE_ID=v3-standard-2
+VOLUME_SIZE=20

--- a/jjb/ci-management/ci-management.yaml
+++ b/jjb/ci-management/ci-management.yaml
@@ -1,0 +1,22 @@
+---
+- project:
+    name: ci-management-project-view
+    project-name: ci-management
+    views:
+      - project-view
+
+- project:
+    name: ci-management-jobs
+    jobs:
+      - "{project-name}-github-ci-jobs"
+
+    project: ci-management
+    project-name: ci-management
+    archive-artifacts: "**/*.log"
+    branch: main
+    build-timeout: 60
+    build-node: centos7-builder-2c-1g
+    jjb-version: 3.5.0
+    # configure the gerrit-jjb-verify job
+    build-node-label-check: true
+    build-node-label-list: ""

--- a/jjb/defaults.yaml
+++ b/jjb/defaults.yaml
@@ -1,0 +1,62 @@
+---
+# GLOBAL jenkins defaults
+
+- defaults:
+    name: global
+
+    github-org: magma
+    git-clone-url: "git@github.com:"
+    git-url: https://github.com
+    github-url: https://github.com
+    # default pr_whitelist to some LF RelEng staff
+    github_pr_whitelist:
+      - jwagantall
+      - fpalumbo-phinx
+    # default pr_admin_list to LF RelEng lead
+    github_pr_admin_list:
+      - jwagantall
+
+    build-days-to-keep: 30
+    # the below discarder values are hard coded into the macro and are only here
+    # for documentation purposes
+    build-num-to-keep: 40
+    build-artifact-days-to-keep: -1
+    build-artifact-num-to-keep: 5
+
+    failure-notification: "releng+magma@linuxfoundation.org"
+    failure-notification-prefix: "[releng]"
+
+    # lf-infra defaults
+    lftools-version: <1.0.0
+
+    # packer_version
+    packer-version: 1.7.2
+
+    # default gerrit server definition
+    server-name: "Primary"
+    gerrit-server-name: "Primary"
+
+    # Java
+    jdk: ""
+
+    # Timeout in minutes
+    build-timeout: 90
+    build-node: ubuntu1804-docker-8c-8g
+
+    archive-artifacts: ""
+
+    # Set default maven version used for everything
+    maven-version: "mvn33"
+
+    # git submodule attributes
+    submodule-recursive: true
+    submodule-disable: false
+
+    # Jenkins
+    jenkins-ssh-credential: "jenkins"
+    jenkins-ssh-release-credential: "magma-release"
+
+    # SonarCloud
+    sonarcloud_project_organization: magma
+    sonarcloud_api_token: 846aa184392cd5f78dc3f073ace0a708198b3bb3
+    sonar_mvn_goal: "org.sonarsource.scanner.maven:sonar-maven-plugin:3.8.0.2131:sonar"


### PR DESCRIPTION
Add basic CI jobs for ci-management repo.
Add also a centos based node dedicated for
these jobs.

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>