### PR TITLE
CI: Fix Key name for GH

### DIFF
--- a/jjb/defaults.yaml
+++ b/jjb/defaults.yaml
@@ -53,7 +53,7 @@
     submodule-disable: false
 
     # Jenkins
-    jenkins-ssh-credential: "jenkins"
+    jenkins-ssh-credential: "jenkins-ssh"
     jenkins-ssh-release-credential: "magma-release"
 
     # SonarCloud


### PR DESCRIPTION
Fix typo on Github SSH Key for Jenkins

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>