### PR TITLE
CI: Fix links to global-jjb

### DIFF
--- a/jjb/global-jjb/jenkins-admin
+++ b/jjb/global-jjb/jenkins-admin
@@ -1,0 +1,1 @@
+../../global-jjb/jenkins-admin

--- a/jjb/global-jjb/jenkins-init-scripts
+++ b/jjb/global-jjb/jenkins-init-scripts
@@ -1,0 +1,1 @@
+../../global-jjb/jenkins-init-scripts

--- a/jjb/global-jjb/jjb
+++ b/jjb/global-jjb/jjb
@@ -1,0 +1,1 @@
+../../global-jjb/jjb

--- a/jjb/global-jjb/shell
+++ b/jjb/global-jjb/shell
@@ -1,0 +1,1 @@
+../../global-jjb/shell


### PR DESCRIPTION
Add missing jjb/global-jjb links to the
global-jjb submodule.

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>