### PR TITLE
[RELENG-3690] Create CLM jobs for Rust and Go

### DIFF
--- a/jjb/clm/clm_go.yaml
+++ b/jjb/clm/clm_go.yaml
@@ -11,5 +11,5 @@
       - gerrit-go-clm
     nexus-iq-namespace: "magma-"
     project: "magma"
-    project-name: "clm-go"
+    project-name: "{project-name}-go-clm-{stream}"
     branch: "master"

--- a/jjb/clm/clm_go.yaml
+++ b/jjb/clm/clm_go.yaml
@@ -1,7 +1,7 @@
 ---
 - project:
-    name: clm-project-view
-    project-name: clm
+    name: clm-go-project-view
+    project-name: clm-go
     views:
       - project-view
 

--- a/jjb/clm/clm_go.yaml
+++ b/jjb/clm/clm_go.yaml
@@ -9,7 +9,7 @@
     name: go-clm
     jobs:
       - gerrit-go-clm
-    nexus-iq-namespace: 'magma-'
-    project: 'magma/magma'
-    project-name: 'clm-go'
-    branch: 'master'
+    nexus-iq-namespace: "magma-"
+    project: "magma/magma"
+    project-name: "clm-go"
+    branch: "master"

--- a/jjb/clm/clm_go.yaml
+++ b/jjb/clm/clm_go.yaml
@@ -1,0 +1,15 @@
+---
+- project:
+    name: clm-project-view
+    project-name: clm
+    views:
+      - project-view
+
+- project:
+    name: go-clm
+    jobs:
+      - gerrit-go-clm
+    nexus-iq-namespace: 'magma-'
+    project: 'magma/magma'
+    project-name: 'clm-go'
+    branch: 'master'

--- a/jjb/clm/clm_go.yaml
+++ b/jjb/clm/clm_go.yaml
@@ -10,6 +10,6 @@
     jobs:
       - gerrit-go-clm
     nexus-iq-namespace: "magma-"
-    project: "magma/magma"
+    project: "magma"
     project-name: "clm-go"
     branch: "master"

--- a/jjb/clm/clm_rust.yaml
+++ b/jjb/clm/clm_rust.yaml
@@ -1,0 +1,15 @@
+---
+- project:
+    name: clm-project-view
+    project-name: clm
+    views:
+      - project-view
+
+- project:
+    name: rust-clm
+    jobs:
+      - gerrit-rust-clm
+    nexus-iq-namespace: 'magma-'
+    project: 'magma/magma'
+    project-name: 'clm-rust'
+    branch: 'master'

--- a/jjb/clm/clm_rust.yaml
+++ b/jjb/clm/clm_rust.yaml
@@ -1,7 +1,7 @@
 ---
 - project:
-    name: clm-project-view
-    project-name: clm
+    name: clm-rust-project-view
+    project-name: clm-rust
     views:
       - project-view
 
@@ -9,7 +9,7 @@
     name: rust-clm
     jobs:
       - gerrit-rust-clm
-    nexus-iq-namespace: 'magma-'
-    project: 'magma/magma'
-    project-name: 'clm-rust'
-    branch: 'master'
+    nexus-iq-namespace: "magma-"
+    project: "magma/magma"
+    project-name: "clm-rust"
+    branch: "master"

--- a/jjb/clm/clm_rust.yaml
+++ b/jjb/clm/clm_rust.yaml
@@ -10,6 +10,6 @@
     jobs:
       - gerrit-rust-clm
     nexus-iq-namespace: "magma-"
-    project: "magma/magma"
-    project-name: "clm-rust"
+    project: "magma"
+    project-name: "{project-name}-rust-clm-{stream}"
     branch: "master"

--- a/jjb/clm/templates/clm-go-templates.yaml
+++ b/jjb/clm/templates/clm-go-templates.yaml
@@ -1,6 +1,5 @@
 - job-template:
     name: "{project-name}-clm-go"
-    node: "ubuntu-dev-teravm"
 
     ######################
     # Default parameters #
@@ -101,7 +100,7 @@
 
 - job-template:
     name: "{project-name}-go-clm-{stream}"
-    id: github-maven-clm
+    id: github-go-clm
 
     properties:
       - lf-infra-properties:

--- a/jjb/clm/templates/clm-go-templates.yaml
+++ b/jjb/clm/templates/clm-go-templates.yaml
@@ -1,0 +1,137 @@
+- job-template:
+    name: "{project-name}-clm-go"
+    node: "ubuntu-dev-teravm"
+
+    ######################
+    # Default parameters #
+    ######################
+
+    branch: master
+    build-days-to-keep: 30 # 30 days for troubleshooting purposes
+    build-timeout: 60
+    disable-job: false
+    git-url: "$GIT_URL/$PROJECT"
+    github-url: "https://github.com"
+    nexus-iq-namespace: "" # Recommend a trailing dash when set. Example: odl-
+    nexus-iq-stage: "build"
+    stream: master
+    submodule-recursive: true
+    submodule-timeout: 10
+    submodule-disable: false
+
+    nexus_iq_scan_patterns:
+      - "**/*.ear"
+      - "**/*.jar"
+      - "**/*.tar.gz"
+      - "**/*.war"
+      - "**/*.zip"
+
+    gerrit_clm_triggers:
+      - comment-added-contains-event:
+          comment-contains-value: '^Patch Set\s+\d+:\s+run-clm\s*$'
+
+    parameters:
+      - lf-infra-parameters:
+          project: "{project}"
+          branch: "{branch}"
+          stream: "{stream}"
+      - string:
+          name: ARCHIVE_ARTIFACTS
+          default: "{archive-artifacts}"
+          description: Artifacts to archive to the logs server.
+      - lf-clm-parameters:
+          nexus-iq-stage: "{nexus-iq-stage}"
+
+    #####################
+    # Job Configuration #
+    #####################
+
+    disabled: "{disable-job}"
+
+    builders:
+      - nexus-iq-policy-evaluator:
+          stage: "{nexus-iq-stage}"
+          application-type: "manual"
+          application-id: "{nexus-iq-namespace}{project-name}"
+          scan-patterns: "{obj:nexus_iq_scan_patterns}"
+          fail-build-network-error: true
+
+#- builder:
+#    name: lf-infra-sonatype-clm
+#    builders:
+#      - inject:
+#          properties-content: |
+#            MAVEN_GOALS={mvn-goals}
+#      - shell: !include-raw-escape:
+#          - ../shell/common-variables.sh
+#          - ../shell/sonatype-clm.sh
+
+- job-template:
+    name: "{project-name}-go-clm-{stream}"
+    id: gerrit-go-clm
+
+    scm:
+      - lf-infra-gerrit-scm:
+          jenkins-ssh-credential: "{jenkins-ssh-credential}"
+          git-url: "{git-url}"
+          refspec: "$GERRIT_REFSPEC"
+          branch: "$GERRIT_BRANCH"
+          submodule-recursive: "{submodule-recursive}"
+          submodule-timeout: "{submodule-timeout}"
+          submodule-disable: "{submodule-disable}"
+          choosing-strategy: default
+
+    triggers:
+      # Build weekly on Saturdays
+      - timed: "H H * * 6"
+      - gerrit:
+          server-name: "{gerrit-server-name}"
+          trigger-on: "{obj:gerrit_clm_triggers}"
+          projects:
+            - project-compare-type: ANT
+              project-pattern: "{project}"
+              branches:
+                - branch-compare-type: ANT
+                  branch-pattern: "**/{branch}"
+          skip-vote:
+            successful: true
+            failed: true
+            unstable: true
+            notbuilt: true
+
+- job-template:
+    name: "{project-name}-go-clm-{stream}"
+    id: github-maven-clm
+
+    properties:
+      - lf-infra-properties:
+          build-days-to-keep: "{build-days-to-keep}"
+      - github:
+          url: "{github-url}/{github-org}/{project}"
+
+    scm:
+      - lf-infra-github-scm:
+          url: "{git-clone-url}{github-org}/{project}"
+          refspec: ""
+          branch: "refs/heads/{branch}"
+          submodule-recursive: "{submodule-recursive}"
+          submodule-timeout: "{submodule-timeout}"
+          submodule-disable: "{submodule-disable}"
+          choosing-strategy: default
+          jenkins-ssh-credential: "{jenkins-ssh-credential}"
+
+    triggers:
+      # Build weekly on Saturdays
+      - timed: "H H * * 6"
+      - github-pull-request:
+          trigger-phrase: "^run-clm$"
+          only-trigger-phrase: true
+          status-context: "CLM"
+          permit-all: true
+          github-hooks: true
+          org-list:
+            - "{github-org}"
+          white-list: "{obj:github_pr_whitelist}"
+          admin-list: "{obj:github_pr_admin_list}"
+          white-list-target-branches:
+            - "{branch}"

--- a/jjb/clm/templates/clm-go-templates.yaml
+++ b/jjb/clm/templates/clm-go-templates.yaml
@@ -1,7 +1,7 @@
 
-#############
-# Go CLM    #
-#############
+##########
+# Go CLM #
+##########
 
 - lf_go_clm: &lf_go_clm
     name: lf-go-clm

--- a/jjb/clm/templates/clm-go-templates.yaml
+++ b/jjb/clm/templates/clm-go-templates.yaml
@@ -1,52 +1,3 @@
-####################
-# COMMON FUNCTIONS #
-####################
-
-- lf_go_common: &lf_go_common
-    name: lf-go-common
-
-    ######################
-    # Default parameters #
-    ######################
-
-    archive-artifacts: >
-      **/*.log
-      **/hs_err_*.log
-      **/target/**/feature.xml
-      **/target/failsafe-reports/failsafe-summary.xml
-      **/target/surefire-reports/*-output.txt
-    #####################
-    # Job Configuration #
-    #####################
-
-    project-type: freestyle
-    node: "{build-node}"
-
-    properties:
-      - lf-infra-properties:
-          build-days-to-keep: "{build-days-to-keep}"
-
-    parameters:
-      - lf-infra-parameters:
-          project: "{project}"
-          branch: "{branch}"
-          stream: "{stream}"
-      - string:
-          name: ARCHIVE_ARTIFACTS
-          default: "{archive-artifacts}"
-          description: Artifacts to archive to the logs server.
-
-    wrappers:
-      - lf-infra-wrappers:
-          build-timeout: "{build-timeout}"
-          jenkins-ssh-credential: "{jenkins-ssh-credential}"
-
-    publishers:
-      # TODO: Make email notification work.
-      # - lf-infra-email-notify:
-      #     email-recipients: '{email-recipients}'
-      #     email-prefix: '[releng]'
-      - lf-infra-publish
 
 #############
 # Go CLM    #
@@ -118,7 +69,7 @@
 - job-template:
     name: "{project-name}-go-clm-{stream}"
     id: gerrit-go-clm
-    <<: *lf_go_common
+    <<: *lf_maven_common
     # yamllint disable-line rule:key-duplicates
     <<: *lf_go_clm
 

--- a/jjb/clm/templates/clm-go-templates.yaml
+++ b/jjb/clm/templates/clm-go-templates.yaml
@@ -1,5 +1,59 @@
-- job-template:
-    name: "{project-name}-clm-go"
+####################
+# COMMON FUNCTIONS #
+####################
+
+- lf_go_common: &lf_go_common
+    name: lf-go-common
+
+    ######################
+    # Default parameters #
+    ######################
+
+    archive-artifacts: >
+      **/*.log
+      **/hs_err_*.log
+      **/target/**/feature.xml
+      **/target/failsafe-reports/failsafe-summary.xml
+      **/target/surefire-reports/*-output.txt
+    #####################
+    # Job Configuration #
+    #####################
+
+    project-type: freestyle
+    node: "{build-node}"
+
+    properties:
+      - lf-infra-properties:
+          build-days-to-keep: "{build-days-to-keep}"
+
+    parameters:
+      - lf-infra-parameters:
+          project: "{project}"
+          branch: "{branch}"
+          stream: "{stream}"
+      - string:
+          name: ARCHIVE_ARTIFACTS
+          default: "{archive-artifacts}"
+          description: Artifacts to archive to the logs server.
+
+    wrappers:
+      - lf-infra-wrappers:
+          build-timeout: "{build-timeout}"
+          jenkins-ssh-credential: "{jenkins-ssh-credential}"
+
+    publishers:
+      # TODO: Make email notification work.
+      # - lf-infra-email-notify:
+      #     email-recipients: '{email-recipients}'
+      #     email-prefix: '[releng]'
+      - lf-infra-publish
+
+#############
+# Go CLM    #
+#############
+
+- lf_go_clm: &lf_go_clm
+    name: lf-go-clm
 
     ######################
     # Default parameters #
@@ -19,11 +73,7 @@
     submodule-disable: false
 
     nexus_iq_scan_patterns:
-      - "**/*.ear"
-      - "**/*.jar"
-      - "**/*.tar.gz"
-      - "**/*.war"
-      - "**/*.zip"
+      - "**/*.go"
 
     gerrit_clm_triggers:
       - comment-added-contains-event:
@@ -68,6 +118,9 @@
 - job-template:
     name: "{project-name}-go-clm-{stream}"
     id: gerrit-go-clm
+    <<: *lf_go_common
+    # yamllint disable-line rule:key-duplicates
+    <<: *lf_go_clm
 
     scm:
       - lf-infra-gerrit-scm:

--- a/jjb/clm/templates/clm-go-templates.yaml
+++ b/jjb/clm/templates/clm-go-templates.yaml
@@ -69,7 +69,7 @@
 - job-template:
     name: "{project-name}-go-clm-{stream}"
     id: gerrit-go-clm
-    <<: *lf_maven_common
+    <<: *lf-maven-common
     # yamllint disable-line rule:key-duplicates
     <<: *lf_go_clm
 

--- a/jjb/clm/templates/clm-rust-templates.yaml
+++ b/jjb/clm/templates/clm-rust-templates.yaml
@@ -1,0 +1,136 @@
+- job-template:
+    name: "{project-name}-clm-rust"
+
+    ######################
+    # Default parameters #
+    ######################
+
+    branch: master
+    build-days-to-keep: 30 # 30 days for troubleshooting purposes
+    build-timeout: 60
+    disable-job: false
+    git-url: "$GIT_URL/$PROJECT"
+    github-url: "https://github.com"
+    nexus-iq-namespace: "" # Recommend a trailing dash when set. Example: odl-
+    nexus-iq-stage: "build"
+    stream: master
+    submodule-recursive: true
+    submodule-timeout: 10
+    submodule-disable: false
+
+    nexus_iq_scan_patterns:
+      - "**/*.ear"
+      - "**/*.jar"
+      - "**/*.tar.gz"
+      - "**/*.war"
+      - "**/*.zip"
+
+    gerrit_clm_triggers:
+      - comment-added-contains-event:
+          comment-contains-value: '^Patch Set\s+\d+:\s+run-clm\s*$'
+
+    parameters:
+      - lf-infra-parameters:
+          project: "{project}"
+          branch: "{branch}"
+          stream: "{stream}"
+      - string:
+          name: ARCHIVE_ARTIFACTS
+          default: "{archive-artifacts}"
+          description: Artifacts to archive to the logs server.
+      - lf-clm-parameters:
+          nexus-iq-stage: "{nexus-iq-stage}"
+
+    #####################
+    # Job Configuration #
+    #####################
+
+    disabled: "{disable-job}"
+
+    builders:
+      - nexus-iq-policy-evaluator:
+          stage: "{nexus-iq-stage}"
+          application-type: "manual"
+          application-id: "{nexus-iq-namespace}{project-name}"
+          scan-patterns: "{obj:nexus_iq_scan_patterns}"
+          fail-build-network-error: true
+
+#- builder:
+#    name: lf-infra-sonatype-clm
+#    builders:
+#      - inject:
+#          properties-content: |
+#            MAVEN_GOALS={mvn-goals}
+#      - shell: !include-raw-escape:
+#          - ../shell/common-variables.sh
+#          - ../shell/sonatype-clm.sh
+
+- job-template:
+    name: "{project-name}-rust-clm-{stream}"
+    id: gerrit-rust-clm
+
+    scm:
+      - lf-infra-gerrit-scm:
+          jenkins-ssh-credential: "{jenkins-ssh-credential}"
+          git-url: "{git-url}"
+          refspec: "$GERRIT_REFSPEC"
+          branch: "$GERRIT_BRANCH"
+          submodule-recursive: "{submodule-recursive}"
+          submodule-timeout: "{submodule-timeout}"
+          submodule-disable: "{submodule-disable}"
+          choosing-strategy: default
+
+    triggers:
+      # Build weekly on Saturdays
+      - timed: "H H * * 6"
+      - gerrit:
+          server-name: "{gerrit-server-name}"
+          trigger-on: "{obj:gerrit_clm_triggers}"
+          projects:
+            - project-compare-type: ANT
+              project-pattern: "{project}"
+              branches:
+                - branch-compare-type: ANT
+                  branch-pattern: "**/{branch}"
+          skip-vote:
+            successful: true
+            failed: true
+            unstable: true
+            notbuilt: true
+
+- job-template:
+    name: "{project-name}-rust-clm-{stream}"
+    id: github-rust-clm
+
+    properties:
+      - lf-infra-properties:
+          build-days-to-keep: "{build-days-to-keep}"
+      - github:
+          url: "{github-url}/{github-org}/{project}"
+
+    scm:
+      - lf-infra-github-scm:
+          url: "{git-clone-url}{github-org}/{project}"
+          refspec: ""
+          branch: "refs/heads/{branch}"
+          submodule-recursive: "{submodule-recursive}"
+          submodule-timeout: "{submodule-timeout}"
+          submodule-disable: "{submodule-disable}"
+          choosing-strategy: default
+          jenkins-ssh-credential: "{jenkins-ssh-credential}"
+
+    triggers:
+      # Build weekly on Saturdays
+      - timed: "H H * * 6"
+      - github-pull-request:
+          trigger-phrase: "^run-clm$"
+          only-trigger-phrase: true
+          status-context: "CLM"
+          permit-all: true
+          github-hooks: true
+          org-list:
+            - "{github-org}"
+          white-list: "{obj:github_pr_whitelist}"
+          admin-list: "{obj:github_pr_admin_list}"
+          white-list-target-branches:
+            - "{branch}"

--- a/jjb/clm/templates/clm-rust-templates.yaml
+++ b/jjb/clm/templates/clm-rust-templates.yaml
@@ -69,7 +69,7 @@
 - job-template:
     name: "{project-name}-go-clm-{stream}"
     id: gerrit-rust-clm
-    <<: *lf_maven_common
+    <<: *lf-maven-common
     # yamllint disable-line rule:key-duplicates
     <<: *lf_rust_clm
 

--- a/jjb/clm/templates/clm-rust-templates.yaml
+++ b/jjb/clm/templates/clm-rust-templates.yaml
@@ -1,56 +1,7 @@
-####################
-# COMMON FUNCTIONS #
-####################
 
-- lf_rust_common: &lf_rust_common
-    name: lf-rust-common
-
-    ######################
-    # Default parameters #
-    ######################
-
-    archive-artifacts: >
-      **/*.log
-      **/hs_err_*.log
-      **/target/**/feature.xml
-      **/target/failsafe-reports/failsafe-summary.xml
-      **/target/surefire-reports/*-output.txt
-    #####################
-    # Job Configuration #
-    #####################
-
-    project-type: freestyle
-    node: "{build-node}"
-
-    properties:
-      - lf-infra-properties:
-          build-days-to-keep: "{build-days-to-keep}"
-
-    parameters:
-      - lf-infra-parameters:
-          project: "{project}"
-          branch: "{branch}"
-          stream: "{stream}"
-      - string:
-          name: ARCHIVE_ARTIFACTS
-          default: "{archive-artifacts}"
-          description: Artifacts to archive to the logs server.
-
-    wrappers:
-      - lf-infra-wrappers:
-          build-timeout: "{build-timeout}"
-          jenkins-ssh-credential: "{jenkins-ssh-credential}"
-
-    publishers:
-      # TODO: Make email notification work.
-      # - lf-infra-email-notify:
-      #     email-recipients: '{email-recipients}'
-      #     email-prefix: '[releng]'
-      - lf-infra-publish
-
-#############
-# rust CLM  #
-#############
+############
+# Rust CLM #
+############
 
 - lf_rust_clm: &lf_rust_clm
     name: lf-rust-clm
@@ -118,7 +69,7 @@
 - job-template:
     name: "{project-name}-go-clm-{stream}"
     id: gerrit-rust-clm
-    <<: *lf_rust_common
+    <<: *lf_maven_common
     # yamllint disable-line rule:key-duplicates
     <<: *lf_rust_clm
 

--- a/jjb/clm/templates/clm-rust-templates.yaml
+++ b/jjb/clm/templates/clm-rust-templates.yaml
@@ -1,5 +1,59 @@
-- job-template:
-    name: "{project-name}-clm-rust"
+####################
+# COMMON FUNCTIONS #
+####################
+
+- lf_rust_common: &lf_rust_common
+    name: lf-rust-common
+
+    ######################
+    # Default parameters #
+    ######################
+
+    archive-artifacts: >
+      **/*.log
+      **/hs_err_*.log
+      **/target/**/feature.xml
+      **/target/failsafe-reports/failsafe-summary.xml
+      **/target/surefire-reports/*-output.txt
+    #####################
+    # Job Configuration #
+    #####################
+
+    project-type: freestyle
+    node: "{build-node}"
+
+    properties:
+      - lf-infra-properties:
+          build-days-to-keep: "{build-days-to-keep}"
+
+    parameters:
+      - lf-infra-parameters:
+          project: "{project}"
+          branch: "{branch}"
+          stream: "{stream}"
+      - string:
+          name: ARCHIVE_ARTIFACTS
+          default: "{archive-artifacts}"
+          description: Artifacts to archive to the logs server.
+
+    wrappers:
+      - lf-infra-wrappers:
+          build-timeout: "{build-timeout}"
+          jenkins-ssh-credential: "{jenkins-ssh-credential}"
+
+    publishers:
+      # TODO: Make email notification work.
+      # - lf-infra-email-notify:
+      #     email-recipients: '{email-recipients}'
+      #     email-prefix: '[releng]'
+      - lf-infra-publish
+
+#############
+# rust CLM  #
+#############
+
+- lf_rust_clm: &lf_rust_clm
+    name: lf-rust-clm
 
     ######################
     # Default parameters #
@@ -19,11 +73,7 @@
     submodule-disable: false
 
     nexus_iq_scan_patterns:
-      - "**/*.ear"
-      - "**/*.jar"
-      - "**/*.tar.gz"
-      - "**/*.war"
-      - "**/*.zip"
+      - "**/*.rs"
 
     gerrit_clm_triggers:
       - comment-added-contains-event:
@@ -66,8 +116,11 @@
 #          - ../shell/sonatype-clm.sh
 
 - job-template:
-    name: "{project-name}-rust-clm-{stream}"
+    name: "{project-name}-go-clm-{stream}"
     id: gerrit-rust-clm
+    <<: *lf_rust_common
+    # yamllint disable-line rule:key-duplicates
+    <<: *lf_rust_clm
 
     scm:
       - lf-infra-gerrit-scm:


### PR DESCRIPTION
Produces a CLM scan of the code into Nexus IQ Server.

**Template Names**
* {project-name}-go-clm-{stream}
* {project-name}-rust-clm-{stream}


**Ticket ID** [link](https://jira.linuxfoundation.org/browse/RELENG-3690)

```
gerrit-go-clm
gerrit-go-clm
github-rust-clm
github-rust-clm

Comment Trigger
run-clm

Required parameters
build-node
The node to run build on.

jenkins-ssh-credential
Credential to use for SSH. (Generally configured in defaults.yaml)

Optional parameters
branch
The branch to build against. (default: master)

build-days-to-keep
Days to keep build logs in Jenkins. (default: 7)

build-timeout
Timeout in minutes before aborting build. (default: 60)

git-url
URL clone project from. (default: $GIT_URL/$PROJECT)

nexus-iq-namespace
Insert a namespace to project AppID for projects that share a Nexus IQ system to avoid project name collision. We recommend inserting a trailing - dash if using this parameter. For example ‘odl-’. (default: ‘’)

nexus-iq-stage
Sets the stage which the policy evaluation will run against on the Nexus IQ Server. (default: ‘build’)

stream
Keyword that represents a release code-name. Often the same as the branch. (default: master)

submodule-recursive
Whether to checkout submodules recursively. (default: true)

submodule-timeout
Timeout (in minutes) for checkout operation. (default: 10)

submodule-disable
Disable submodule checkout operation. (default: false)

gerrit_merge_triggers
Override Gerrit Triggers.
```
