### PR TITLE
Fix: Add missing packer templates

### DIFF
--- a/packer/templates/builder.json
+++ b/packer/templates/builder.json
@@ -1,0 +1,1 @@
+../common-packer/templates/builder.json

--- a/packer/templates/docker.json
+++ b/packer/templates/docker.json
@@ -1,0 +1,1 @@
+../common-packer/templates/docker.json


### PR DESCRIPTION
Add packer templates for docker and builder
images.

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>