### PR TITLE
refactor: Migrate vagrant pipelines

### DIFF
--- a/jjb/vagrant/vagrant-templates.yaml
+++ b/jjb/vagrant/vagrant-templates.yaml
@@ -1,0 +1,83 @@
+---
+############
+# BUILDERS #
+############
+
+###########
+# ANCHORS #
+###########
+- vagrant_common: &vagrant_common
+    name: vagrant_common
+
+    ######################
+    # Default parameters #
+    ######################
+
+    branch: master
+
+    #####################
+    # Job Configuration #
+    #####################
+
+    project-type: pipeline
+    node: "{build-node}"
+
+    parameters:
+      - string:
+          name: BRANCH
+          default: "{branch}"
+
+#################
+# JOB TEMPLATES #
+#################
+- job-template:
+    name: "vagrant_build"
+    description: "Job template for vagrant build pipeline jobs"
+
+    <<: *vagrant_common
+    concurrent: false
+    sandbox: true
+
+    properties:
+      - github:
+          url: "https://github.com/{github-org}/{project}"
+          display-name: "Magma"
+
+    pipeline-scm:
+      script-path: ci-scripts/JenkinsFile-build-vagrant-boxes
+      scm:
+        - lf-infra-github-scm:
+            url: "{git-clone-url}{github-org}/{project}"
+            refspec: ""
+            branch: "refs/heads/{branch}"
+            submodule-recursive: "{submodule-recursive}"
+            choosing-strategy: default
+            jenkins-ssh-credential: "{jenkins-ssh-credential}"
+            submodule-disable: true
+            submodule-timeout: 10
+
+- job-template:
+    name: "vagrant_build_test"
+    description: "Builds Vagrant boxes for Magma project and publishes them"
+
+    <<: *vagrant_common
+    concurrent: false
+    sandbox: true
+
+    properties:
+      - github:
+          url: "https://github.com/{github-org}/{project}"
+          display-name: "Magma"
+
+    pipeline-scm:
+      script-path: ci-scripts/JenkinsFile-build-vagrant-boxes
+      scm:
+        - lf-infra-github-scm:
+            url: "{git-clone-url}{github-org}/{project}"
+            refspec: ""
+            branch: "refs/heads/{branch}"
+            submodule-recursive: "{submodule-recursive}"
+            choosing-strategy: default
+            jenkins-ssh-credential: "{jenkins-ssh-credential}"
+            submodule-disable: true
+            submodule-timeout: 10

--- a/jjb/vagrant/vagrant.yaml
+++ b/jjb/vagrant/vagrant.yaml
@@ -1,0 +1,14 @@
+---
+- project:
+    name: vagrant-project-view
+    project-name: vagrant
+    views:
+      - project-view
+
+- project:
+    name: vagrant-build
+    project: magma
+    branch: master
+    jobs:
+      - "vagrant_build"
+      - "vagrant_build_test"


### PR DESCRIPTION
Migrate vagrant_build and vagrant_build_test
to LF's hosted Jenkins.

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>