### PR TITLE
chore: Add bigger instance size to test performance of integ tests

### DIFF
--- a/jenkins-config/clouds/openstack/vex/ubuntu2004-docker-16c-64g.cfg
+++ b/jenkins-config/clouds/openstack/vex/ubuntu2004-docker-16c-64g.cfg
@@ -1,0 +1,4 @@
+IMAGE_NAME=ZZCI - Ubuntu 20.04 - docker - x86_64 - 20210818-201059.462
+LABELS=ubuntu2004-docker-16c-64g ubuntu2004-docker-16c-64g
+HARDWARE_ID=v3-standard-16
+VOLUME_SIZE=40


### PR DESCRIPTION
Integ tests are taking ~ 4 hours to run.
Will test them out on a bigger instance