### PR TITLE
Refactor: Migrate vagrant pipelines

### DIFF
--- a/jjb/magma/magma-jobs.yaml
+++ b/jjb/magma/magma-jobs.yaml
@@ -12,3 +12,12 @@
     branch: master
     jobs:
       - "cwag-integration-test-libvirt"
+
+- project:
+    name: magma-vagrant
+    disabled: true
+    project: magma
+    branch: master
+    jobs:
+      - "vagrant_build"
+      - "vagrant_build_test"

--- a/jjb/magma/magma-vagrant-templates.yaml
+++ b/jjb/magma/magma-vagrant-templates.yaml
@@ -1,0 +1,86 @@
+---
+############
+# BUILDERS #
+############
+
+###########
+# ANCHORS #
+###########
+- vagrant_common: &vagrant_common
+    name: vagrant_common
+
+    ######################
+    # Default parameters #
+    ######################
+
+    branch: master
+
+    #####################
+    # Job Configuration #
+    #####################
+
+    project-type: pipeline
+    node: "{build-node}"
+    disabled: false
+
+    parameters:
+      - string:
+          name: BRANCH
+          default: "{branch}"
+
+#################
+# JOB TEMPLATES #
+#################
+- job-template:
+    name: "vagrant_build"
+    description: "Job template for vagrant build pipeline jobs"
+
+    <<: *vagrant_common
+    concurrent: false
+    sandbox: true
+    disabled: "{disabled}"
+
+    properties:
+      - github:
+          url: "https://github.com/{github-org}/{project}"
+          display-name: "Magma"
+
+    pipeline-scm:
+      script-path: ci-scripts/JenkinsFile-build-vagrant-boxes
+      scm:
+        - lf-infra-github-scm:
+            url: "{git-clone-url}{github-org}/{project}"
+            refspec: ""
+            branch: "refs/heads/{branch}"
+            submodule-recursive: "{submodule-recursive}"
+            choosing-strategy: default
+            jenkins-ssh-credential: "{jenkins-ssh-credential}"
+            submodule-disable: true
+            submodule-timeout: 10
+
+- job-template:
+    name: "vagrant_build_test"
+    description: "Builds Vagrant boxes for Magma project and publishes them"
+
+    <<: *vagrant_common
+    concurrent: false
+    sandbox: true
+    disabled: "{disabled}"
+
+    properties:
+      - github:
+          url: "https://github.com/{github-org}/{project}"
+          display-name: "Magma"
+
+    pipeline-scm:
+      script-path: ci-scripts/JenkinsFile-build-vagrant-boxes
+      scm:
+        - lf-infra-github-scm:
+            url: "{git-clone-url}{github-org}/{project}"
+            refspec: ""
+            branch: "refs/heads/{branch}"
+            submodule-recursive: "{submodule-recursive}"
+            choosing-strategy: default
+            jenkins-ssh-credential: "{jenkins-ssh-credential}"
+            submodule-disable: true
+            submodule-timeout: 10


### PR DESCRIPTION
Migrate vagrant_build and vagrant_build_test
to LF's hosted Jenkins.

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>